### PR TITLE
chore: semantic prereleases includes git sha

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,12 @@
+// Configuration for semantic-release
+module.exports = {
+  branches: [
+    "+([0-9])?(.{+([0-9]),x}).x",
+    "master",
+    {
+      name: "!(+([0-9])?(.{+([0-9]),x}).x|master)",
+      prerelease: "${ name }" + `-${process.env.CIRCLE_SHA1}`
+    }
+  ],
+  pkgRoot: "pkg"
+}


### PR DESCRIPTION
amending / force pushing to a branch breaks prereleases. it seems that when the history changes, it does not fetch the tags belonging to now orphaned commits.